### PR TITLE
add $(inherited) for using cocoapods

### DIFF
--- a/SkyWay-iOS-Sample.xcodeproj/project.pbxproj
+++ b/SkyWay-iOS-Sample.xcodeproj/project.pbxproj
@@ -365,7 +365,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ntt.SkyWay-iOS-Sample";
 				PRODUCT_NAME = "SkyWay-iOS-Sample";
 				PROVISIONING_PROFILE = "";
@@ -389,7 +392,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ntt.SkyWay-iOS-Sample";
 				PRODUCT_NAME = "SkyWay-iOS-Sample";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
$(inherited) がないとcocoa podsの設定が上書きされてしまうので追記しました。