### PR TITLE
add privacy info for iOS10 support

### DIFF
--- a/SkyWay-iOS-Sample/Info.plist
+++ b/SkyWay-iOS-Sample/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>for voice chat</string>
+	<key>NSCameraUsageDescription</key>
+	<string>for video chat</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ja_JP</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
This is a setting to use video and microphone to provide videochat.
When the app try to use video/microphone , popup window to allow( or deny) using video/microphone will appear with below string.

> \<string>for voice chat\</string>

official document is below
https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24

> If your app attempts to access the device’s camera without a corresponding purpose string, your app exits.
