### PR TITLE
Migrate LaunchImage.xcassets

### DIFF
--- a/SkyWay-iOS-Sample/Images.xcassets/LaunchImage.launchimage/Contents.json
+++ b/SkyWay-iOS-Sample/Images.xcassets/LaunchImage.launchimage/Contents.json
@@ -33,6 +33,7 @@
       "idiom" : "iphone",
       "filename" : "Default@2x.png",
       "minimum-system-version" : "7.0",
+      "extent" : "full-screen",
       "scale" : "2x"
     },
     {
@@ -40,6 +41,7 @@
       "idiom" : "iphone",
       "filename" : "Default-568h@2x.png",
       "minimum-system-version" : "7.0",
+      "extent" : "full-screen",
       "subtype" : "retina4",
       "scale" : "2x"
     }


### PR DESCRIPTION
Warning: The launch image set "LaunchImage" has 2 unassigned children.

fixes #16